### PR TITLE
Profile Section: Current User Reports location

### DIFF
--- a/js/components/reports/userReportLocation.js
+++ b/js/components/reports/userReportLocation.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import MapView from 'react-native-maps';
+import { StyleSheet, Text, View} from 'react-native';
+
+export default class userReportLocation extends React.Component {
+
+    render() {
+        return (
+            <View style={styles.container}>
+                <MapView style={styles.map}
+                    initialRegion={{
+                        latitude: this.props.latitude,
+                        longitude: this.props.longitude,
+                        latitudeDelta: 0.0,
+                        longitudeDelta: 0.0,
+                    }}
+                >
+                    <MapView.Marker
+                        coordinate={{
+                            latitude: this.props.latitude,
+                            longitude: this.props.longitude,
+                        }}
+                        title={"Corona"}
+                        description={"Chitransh Anand"}
+                    />
+                </MapView>
+            </View>
+        );
+    }
+}
+
+var styles = StyleSheet.create({
+
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF',
+    },
+    map: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+    }
+});


### PR DESCRIPTION
This fixes #265 

Reports Location Screen
Props(containing the location coordinates) are passed to this screen and ```react-native-maps``` is used to put a marker on the maps depicting the report location.

![image](https://user-images.githubusercontent.com/43493203/77952441-4cd20480-72e9-11ea-9ffb-7c3be216edfa.png)
