### PR TITLE
Analytics Section: Bar Graph of number of cases

### DIFF
--- a/js/status/barChart.js
+++ b/js/status/barChart.js
@@ -2,12 +2,47 @@ import React from 'react'
 import { View } from 'react-native'
 import { BarChart, Grid } from 'react-native-svg-charts'
 import { Text } from 'react-native-svg'
+import firebase from 'firebase'
+import '@firebase/firestore';
 
 export default class barChart extends React.PureComponent {
+    
+    state = {
+        reports: [],
+        data: []
+    }
+    
+    componentDidMount() {
+        reports = []
+        data = []
+        dates = []
+        const ref = firebase.firestore().collection('reports')
+        let allReports = ref.get().then(snapshot => {
+            snapshot.forEach(doc => {
+                reports.push(doc.data())
+                let date = new date(doc.data().timeStamp)
+                dates.push(date)
+            })
+            this.setState({ reports: reports })
+            console.log(this.state.reports)
+        })
+        let count = 0;
+        for (let i = 0; i < dates.length; i++) {
+            if (dates[i] == dates[i + 1]) {
+                count++;
+            }
+            else {
+                dates.push(count + 1)
+                count = 0
+            }
+        }
+        
+        this.setState({ data: dates.slice(0,5) })
+    }
 
     render() {
 
-        const data = [10, 5, 25, 15, 20]
+        const data = this.state.data
 
         const CUT_OFF = 20
         const Labels = ({ x, y, bandwidth, data }) => (

--- a/js/status/barChart.js
+++ b/js/status/barChart.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { View } from 'react-native'
+import { BarChart, Grid } from 'react-native-svg-charts'
+import { Text } from 'react-native-svg'
+
+export default class barChart extends React.PureComponent {
+
+    render() {
+
+        const data = [10, 5, 25, 15, 20]
+
+        const CUT_OFF = 20
+        const Labels = ({ x, y, bandwidth, data }) => (
+            data.map((value, index) => (
+                <Text
+                    key={index}
+                    x={x(index) + (bandwidth / 2)}
+                    y={value < CUT_OFF ? y(value) - 10 : y(value) + 15}
+                    fontSize={14}
+                    fill={value >= CUT_OFF ? 'white' : 'black'}
+                    alignmentBaseline={'middle'}
+                    textAnchor={'middle'}
+                >
+                    {value}
+                </Text>
+            ))
+        )
+
+        return (
+            <View style={{ flexDirection: 'row', height: 200, paddingVertical: 16 }}>
+                <BarChart
+                    style={{ flex: 1 }}
+                    data={data}
+                    svg={{ fill: 'rgba(134, 65, 244, 0.8)' }}
+                    contentInset={{ top: 10, bottom: 10 }}
+                    spacing={0.2}
+                    gridMin={0}
+                >
+                    <Grid direction={Grid.Direction.HORIZONTAL} />
+                    <Labels />
+                </BarChart>
+            </View>
+        )
+    }
+
+}
+


### PR DESCRIPTION
This solves #284   
  
Bar Graph Screen  
In the Analytics Section, users can view the graphs, charts, trends of reports and status of an area.
Users can view the number of cases of the past 5 days worldwide.  

![image](https://user-images.githubusercontent.com/43493203/78461288-4676ca80-76e5-11ea-9219-c4e74a44c3be.png)  
  
Data is fetched from firebase and converted into meaningful data to be used for trends screen with the help of ```react-native-svg-charts```.  
  
This code snippet will convert the data into meaningful data:-  
`for (let i = 0; i < dates.length; i++) {`
 `           if (dates[i] == dates[i + 1]) {`
  `              count++;`
   `         }`
    `        else {`
     `           dates.push(count + 1)`
      `          count = 0`
       `     }`
        `}`
        `this.setState({ data: dates.slice(0,5) })`

